### PR TITLE
Add an option to log the file and line

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func (e E) Error() string {
 
 func main() {
 	stdr.SetVerbosity(1)
-	log := stdr.New(stdlog.New(os.Stderr, "", stdlog.LstdFlags|stdlog.Lshortfile))
+	log := stdr.NewWithOptions(stdlog.New(os.Stderr, "", stdlog.LstdFlags), stdr.Options{LogCaller: stdr.All})
 	log = log.WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
 	log.V(1).Info("you should see this")


### PR DESCRIPTION
This adds an optional "caller" key in the structured portion of the
line.  This is independent of the normal log header, which can be
enabled or disabled in the crteation of the standard logger.