### PR TITLE
Add benchmark test with alloc

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	stdlog "log"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
+)
+
+func init() {
+	stdr.SetVerbosity(1)
+	os.Stderr, _ = os.Open("/dev/null")
+}
+
+//go:noinline
+func doInfoOneArg(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		log.Info("this is", "a", "string")
+	}
+}
+
+//go:noinline
+func doInfoSeveralArgs(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		log.Info("multi",
+			"bool", true, "string", "str", "int", 42,
+			"float", 3.14, "struct", struct{ X, Y int }{93, 76})
+	}
+}
+
+//go:noinline
+func doV0Info(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		log.V(0).Info("multi",
+			"bool", true, "string", "str", "int", 42,
+			"float", 3.14, "struct", struct{ X, Y int }{93, 76})
+	}
+}
+
+//go:noinline
+func doV9Info(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		log.V(9).Info("multi",
+			"bool", true, "string", "str", "int", 42,
+			"float", 3.14, "struct", struct{ X, Y int }{93, 76})
+	}
+}
+
+//go:noinline
+func doError(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	err := fmt.Errorf("error message")
+	for i := 0; i < b.N; i++ {
+		log.Error(err, "multi",
+			"bool", true, "string", "str", "int", 42,
+			"float", 3.14, "struct", struct{ X, Y int }{93, 76})
+	}
+}
+
+//go:noinline
+func doWithValues(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l := log.WithValues("k1", "v1", "k2", "v2")
+		_ = l
+	}
+}
+
+//go:noinline
+func doWithName(b *testing.B, log logr.Logger) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l := log.WithName("name")
+		_ = l
+	}
+}
+
+func logger() logr.Logger {
+	return stdr.New(stdlog.New(os.Stderr, "", 0))
+}
+
+func BenchmarkDiscardInfoOneArg(b *testing.B) {
+	var log logr.Logger = logger()
+	doInfoOneArg(b, log)
+}
+
+func BenchmarkDiscardInfoSeveralArgs(b *testing.B) {
+	var log logr.Logger = logger()
+	doInfoSeveralArgs(b, log)
+}
+
+func BenchmarkDiscardV0Info(b *testing.B) {
+	var log logr.Logger = logger()
+	doV0Info(b, log)
+}
+
+func BenchmarkDiscardV9Info(b *testing.B) {
+	var log logr.Logger = logger()
+	doV9Info(b, log)
+}
+
+func BenchmarkDiscardError(b *testing.B) {
+	var log logr.Logger = logger()
+	doError(b, log)
+}
+
+func BenchmarkDiscardWithValues(b *testing.B) {
+	var log logr.Logger = logger()
+	doWithValues(b, log)
+}
+
+func BenchmarkDiscardWithName(b *testing.B) {
+	var log logr.Logger = logger()
+	doWithName(b, log)
+}
+
+func BenchmarkFuncrInfoOneArg(b *testing.B) {
+	var log logr.Logger = logger()
+	doInfoOneArg(b, log)
+}
+
+func BenchmarkFuncrInfoSeveralArgs(b *testing.B) {
+	var log logr.Logger = logger()
+	doInfoSeveralArgs(b, log)
+}
+
+func BenchmarkFuncrV0Info(b *testing.B) {
+	var log logr.Logger = logger()
+	doV0Info(b, log)
+}
+
+func BenchmarkFuncrV9Info(b *testing.B) {
+	var log logr.Logger = logger()
+	doV9Info(b, log)
+}
+
+func BenchmarkFuncrError(b *testing.B) {
+	var log logr.Logger = logger()
+	doError(b, log)
+}
+
+func BenchmarkFuncrWithValues(b *testing.B) {
+	var log logr.Logger = logger()
+	doWithValues(b, log)
+}
+
+func BenchmarkFuncrWithName(b *testing.B) {
+	var log logr.Logger = logger()
+	doWithName(b, log)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-logr/stdr
 
 go 1.16
 
-require github.com/go-logr/logr v1.0.0-rc1
+require github.com/go-logr/logr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.0.0-rc1 h1:+ul9F74rBkPajeP8m4o3o0tiglmzNFsPnuhYyBCQ0Sc=
-github.com/go-logr/logr v1.0.0-rc1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
```
go version go1.16.6 linux/amd64

cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
BenchmarkDiscardInfoOneArg-8             1319188               892.8 ns/op           232 B/op          8 allocs/op
BenchmarkDiscardInfoSeveralArgs-8         742125              1580 ns/op             552 B/op         14 allocs/op
BenchmarkDiscardV0Info-8                  755325              1621 ns/op             552 B/op         14 allocs/op
BenchmarkDiscardV9Info-8                 8628398               133.5 ns/op           176 B/op          2 allocs/op
BenchmarkDiscardError-8                   693415              1715 ns/op             600 B/op         16 allocs/op
BenchmarkDiscardWithValues-8            n 4856173              242.6 ns/op           208 B/op          3 allocs/op
BenchmarkDiscardWithName-8              12319874                85.29 ns/op           80 B/op          1 allocs/op
BenchmarkFuncrInfoOneArg-8               1332094               904.2 ns/op           232 B/op          8 allocs/op
BenchmarkFuncrInfoSeveralArgs-8           689158              1561 ns/op             552 B/op         14 allocs/op
BenchmarkFuncrV0Info-8                    769890              1629 ns/op             552 B/op         14 allocs/op
BenchmarkFuncrV9Info-8                   8916390               138.0 ns/op           176 B/op          2 allocs/op
BenchmarkFuncrError-8                     693705              1723 ns/op             600 B/op         16 allocs/op
BenchmarkFuncrWithValues-8               4718301               251.3 ns/op           208 B/op          3 allocs/op
BenchmarkFuncrWithName-8                12068954                91.43 ns/op           80 B/op          1 allocs/op
```