### PR TITLE
move code examples

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package stdr_test
 
 import (
 	"errors"


### PR DESCRIPTION
https://pkg.go.dev/github.com/go-logr/stdr@v1.1.0 did not pick them up when
placed in the "example" directory.